### PR TITLE
Fix event handling

### DIFF
--- a/src/handleEvent.ts
+++ b/src/handleEvent.ts
@@ -92,7 +92,7 @@ export function handleEvent<Context = unknown, Event = unknown>(
                 handler.Condition,
                 {
                     Value: event,
-                    ...(context || {}),
+                    ...(newContext || {}),
                     ...(definition.Constants || {}),
                 },
                 {
@@ -119,7 +119,7 @@ export function handleEvent<Context = unknown, Event = unknown>(
 
                         referenceArray.push(item)
 
-                        set(context, reference, referenceArray)
+                        set(newContext, reference, referenceArray)
 
                         return true
                     },

--- a/src/handleEvent.ts
+++ b/src/handleEvent.ts
@@ -55,7 +55,7 @@ export function handleEvent<Context = unknown, Event = unknown>(
         // - we have no handler for the current state
         // - in this particular state, the state machine doesn't care about the current event
         return {
-            context: definition.Context,
+            context: context,
             state: currentState,
         }
     }

--- a/tests/handleEvent.spec.ts
+++ b/tests/handleEvent.spec.ts
@@ -64,7 +64,7 @@ describe("handleEvent api", () => {
                 )
             }
 
-            if (event === 5) {
+            if (event === 4) {
                 assert.strictEqual(
                     result.state,
                     "NumberIsFive",
@@ -76,7 +76,7 @@ describe("handleEvent api", () => {
             assert.strictEqual(
                 result.state,
                 "Start",
-                "we should not have transitioned yet"
+                `Currently at event number ${event}. we should not have transitioned yet`
             )
         }
     })


### PR DESCRIPTION
- When the state machine doesn't care about the current event, we should return the original context, instead of the default context. This is because there might be data stored in the original context (e.g. `"context":{"Count":2}`), and returning the default context will cause this information to be lost.
- After we have deep-copied the context, the original `context` should not be used anymore. Instead, the `newContext` should be used. 

This PR fixes several broken challenges that require updating fields in the `context` to meet a `goal`.  such as The Personal Touch. 