### PR TITLE
Remove timer upon completion

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -211,7 +211,19 @@ function realTest<Variables, Return = Variables | boolean>(
             log("eventStamp", String(options.eventTimestamp))
             log("endTime", String(timer.endTime))
 
-            return options.eventTimestamp >= timer.endTime
+            if (options.eventTimestamp >= timer.endTime) {
+                const index = options.timers.findIndex(
+                    (timer) => timer.path === path
+                )
+
+                if (index !== -1) {
+                    options.timers.splice(index, 1)
+                }
+
+                return true
+            } else {
+                return false
+            }
         }
 
         if (has("$pushunique")) {
@@ -330,11 +342,7 @@ export function handleActions<Context>(
         const variableValue1 = findNamedChild(input["$mul"][0], context)
         const variableValue2 = findNamedChild(input["$mul"][1], context)
 
-        set(
-            context,
-            reference,
-            variableValue1 * variableValue2
-        )
+        set(context, reference, variableValue1 * variableValue2)
     }
 
     if (has("$set")) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -212,6 +212,8 @@ function realTest<Variables, Return = Variables | boolean>(
             log("endTime", String(timer.endTime))
 
             if (options.eventTimestamp >= timer.endTime) {
+                // The timer is up. Delete it from the timers array
+                // so that a new timer can be created if this state is visited again.
                 const index = options.timers.findIndex(
                     (timer) => timer.path === path
                 )
@@ -221,9 +223,9 @@ function realTest<Variables, Return = Variables | boolean>(
                 }
 
                 return true
-            } else {
-                return false
             }
+
+            return false
         }
 
         if (has("$pushunique")) {

--- a/tests/timers.spec.ts
+++ b/tests/timers.spec.ts
@@ -57,20 +57,15 @@ describe("$after", () => {
     })
 
     it("supports basic timers", () => {
-        function validate(timers: Timer[]) {
-            assert.strictEqual(timers.length, 1, "incorrect timer count")
-            assert.strictEqual(timers[0].startTime, 0, "start time not correct")
-            assert.strictEqual(timers[0].endTime, 8, "end time not correct")
-        }
-
         const [sm, vars] = data.After2
 
         const timers: Timer[] = []
 
         const result = test(sm, vars, { timers, eventTimestamp: 0 })
 
-        validate(timers)
-
+        assert.strictEqual(timers.length, 1, "incorrect timer count")
+        assert.strictEqual(timers[0].startTime, 0, "start time not correct")
+        assert.strictEqual(timers[0].endTime, 8, "end time not correct")
         assert.strictEqual(result, false, "timer returned true")
 
         // now, let's try again, pretending 8 seconds have passed
@@ -79,8 +74,7 @@ describe("$after", () => {
             eventTimestamp: 8,
         })
 
-        validate(timers)
-
+        assert.strictEqual(timers.length, 0, "incorrect timer count")
         assert.strictEqual(result2, true, "timer returned false")
     })
 })

--- a/tests/timers.spec.ts
+++ b/tests/timers.spec.ts
@@ -76,5 +76,25 @@ describe("$after", () => {
 
         assert.strictEqual(timers.length, 0, "incorrect timer count")
         assert.strictEqual(result2, true, "timer returned false")
+
+        // Without a timer in effect, a new timer should be created.
+        const result3 = test(sm, vars, {
+            timers,
+            eventTimestamp: 9,
+        })
+
+        assert.strictEqual(timers.length, 1, "incorrect timer count")
+        assert.strictEqual(timers[0].startTime, 9, "start time not correct")
+        assert.strictEqual(timers[0].endTime, 17, "end time not correct")
+        assert.strictEqual(result3, false, "timer returned true")
+
+        // The second timer is up.
+        const result4 = test(sm, vars, {
+            timers,
+            eventTimestamp: 18,
+        })
+
+        assert.strictEqual(timers.length, 0, "incorrect timer count")
+        assert.strictEqual(result4, true, "timer returned false")
     })
 })


### PR DESCRIPTION
Love Triangle enters the `TargetBodyDumpUsed` state twice. This state has a timer, and a new timer should be created each time this state is entered. The challenge is not working because when the state is entered a second time, the SMP is still using the previous timer.

This PR removes a timer from the `timers` array when its timer is up, so that the next time this state is entered, a new timer will be created. Tests are fixed accordingly.