### PR TITLE
Support contract IDs for `$pushunique`

### DIFF
--- a/src/handleEvent.ts
+++ b/src/handleEvent.ts
@@ -151,8 +151,8 @@ export function handleEvent<Context = unknown, Event = unknown>(
                         },
                         {
                             Value: event,
-                            ...(options.ContractId && {
-                                ContractId: options.ContractId,
+                            ...(options.contractId && {
+                                ContractId: options.contractId,
                             }),
                             ...newContext,
                         },

--- a/src/handleEvent.ts
+++ b/src/handleEvent.ts
@@ -151,6 +151,9 @@ export function handleEvent<Context = unknown, Event = unknown>(
                         },
                         {
                             Value: event,
+                            ...(options.ContractId && {
+                                ContractId: options.ContractId,
+                            }),
                             ...newContext,
                         },
                         {}
@@ -163,6 +166,13 @@ export function handleEvent<Context = unknown, Event = unknown>(
             if (newContext.Value) {
                 // @ts-expect-error
                 delete newContext.Value
+            }
+
+            // drop this specific event's ContractId
+            // @ts-expect-error
+            if (newContext.ContractId) {
+                // @ts-expect-error
+                delete newContext.ContractId
             }
 
             // drop the constants

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,7 +79,7 @@ export interface HandleEventOptions extends Partial<LoggingProvider> {
      * The contractId of the session the event took place in.
      * @since v5.4.0
      */
-    ContractId?: string
+    contractId?: string
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,12 @@ export interface HandleEventOptions extends Partial<LoggingProvider> {
      * The time the event happened at.
      */
     timestamp: GameTimestamp
+
+    /**
+     * The contractId of the session the event took place in.
+     * @since v5.4.0
+     */
+    ContractId?: string
 }
 
 /**


### PR DESCRIPTION
Add support for passing `ContractId` to `handleEvent` and then to `handleActions`, in order for contract IDs to be supported by `$pushunique`.

Ultimately this is to support Featured Contract challenges, which need to push contract IDs into an array uniquely. A sample `Definition` is attached below.

```json
"Definition": {
    "Constants": {
        "Goal": 5,
        "Locations": [
            "LOCATION_PARIS",
            "LOCATION_COASTALTOWN",
            "LOCATION_COASTALTOWN_NIGHT",
            "LOCATION_COASTALTOWN_MOVIESET",
            "LOCATION_COASTALTOWN_EBOLA",
            "LOCATION_MARRAKECH",
            "LOCATION_MARRAKECH_NIGHT",
            "LOCATION_BANGKOK",
            "LOCATION_BANGKOK_ZIKA",
            "LOCATION_COLORADO",
            "LOCATION_COLORADO_RABIES",
            "LOCATION_HOKKAIDO",
            "LOCATION_HOKKAIDO_FLU",
            "LOCATION_NEWZEALAND",
            "LOCATION_MIAMI",
            "LOCATION_COLOMBIA",
            "LOCATION_COLOMBIA_ANACONDA",
            "LOCATION_MUMBAI",
            "LOCATION_MUMBAI_KINGCOBRA",
            "LOCATION_NORTHAMERICA",
            "LOCATION_NORTHSEA",
            "LOCATION_GREEDY_RACCOON",
            "LOCATION_OPULENT_STINGRAY"
        ]
    },
    "Context": {
        "Completed": []
    },
    "ContextListeners": {
        "Count": {
            "count": "($.Completed).Count",
            "total": "$.Goal",
            "type": "challengecounter"
        }
    },
    "Scope": "hit",
    "States": {
        "Start": {
            "ContractStart": {
                "Condition": {
                    "$and": [
                        {
                            "$eq": [
                                "$Value.ContractType",
                                "featured"
                            ]
                        },
                        {
                            "$any": {
                                "?": {
                                    "$eq": [
                                        "$.#",
                                        "$Value.LocationId"
                                    ]
                                },
                                "in": "$.Locations"
                            }
                        }
                    ]
                },
                "Transition": "State_ValidContract"
            }
        },
        "State_ValidContract": {
            "ContractEnd": [
                {
                    "Actions": {
                        "$pushunique": [
                            "Completed",
                            "$ContractId"
                        ]
                    }
                },
                {
                    "Condition": {
                        "$eq": [
                            "($.Completed).Count",
                            "$.Goal"
                        ]
                    },
                    "Transition": "Success"
                },
                {
                    "Transition": "Start"
                }
            ],
            "ContractStart": {
                "Condition": {
                    "$not": {
                        "$eq": [
                            "$Value.ContractType",
                            "featured"
                        ]
                    }
                },
                "Transition": "Start"
            }
        }
    }
}
```