### PR TITLE
Support long arrays for `$eq`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -102,15 +102,25 @@ function realTest<Variables, Return = Variables | boolean>(
 
         if (has("$eq")) {
             // transform any strings inside these arrays into their intended context values
-            if (Array.isArray(input.$eq[0] || input.$eq[1])) {
+            if (input.$eq.some((val) => Array.isArray(val))) {
                 log("validation", "attempted to compare arrays (can't!)")
                 return false
             }
 
+            const res = testWithPath(input.$eq[0], variables, options, "$eq[0]")
+
             return (
-                // we test twice because we need to make sure that the value is fixed if it's a variable
-                testWithPath(input.$eq[0], variables, options, "$eq[0]") ===
-                testWithPath(input.$eq[1], variables, options, "$eq[1]")
+                // we test for each element because we need to make sure that the value is fixed if it's a variable
+                input.$eq.every(
+                    (val, index) =>
+                        index === 0 ||
+                        testWithPath(
+                            val,
+                            variables,
+                            options,
+                            `$eq[${index}]`
+                        ) === res
+                )
             )
         }
 

--- a/tests/eq.spec.ts
+++ b/tests/eq.spec.ts
@@ -69,6 +69,12 @@ const data = {
         },
         {},
     ],
+    LongArray1: [
+        {
+            $eq: [1, 1, 1, 1],
+        },
+        {},
+    ],
 }
 
 describe("$eq", () => {
@@ -104,5 +110,10 @@ describe("$eq", () => {
             const [sm, vars] = data.NestedNeq1
             assert.strictEqual(test(sm, vars), false)
         })
+    })
+
+    it("array with more than 2 elements", () => {
+        const [sm, vars] = data.LongArray1
+        assert.strictEqual(test(sm, vars), true)
     })
 })


### PR DESCRIPTION
- Support arrays with more than 2 elements for `$eq`. Fixes Tightening the Screw because it uses an `$eq` with four elements.
- Added a test for this.