### PR TITLE
Pass contract Ids to condition checks and transition handlers

### DIFF
--- a/src/handleEvent.ts
+++ b/src/handleEvent.ts
@@ -92,6 +92,9 @@ export function handleEvent<Context = unknown, Event = unknown>(
                 handler.Condition,
                 {
                     Value: event,
+                    ...(options.contractId && {
+                        ContractId: options.contractId,
+                    }),
                     ...(newContext || {}),
                     ...(definition.Constants || {}),
                 },
@@ -201,6 +204,7 @@ export function handleEvent<Context = unknown, Event = unknown>(
                     logger: log,
                     timers: options.timers,
                     timestamp: options.timestamp,
+                    contractId: options.contractId,
                 }
             )
         }


### PR DESCRIPTION
Previously contract Ids were only passed to action handlers for `$pushunique`. Turned out that they are also needed for condition checking, so this PR added them in a similar fashion. They are now also passed when handling transitions in case they are needed there as well.