### PR TITLE
Fix irregular events being handled incorrectly

### DIFF
--- a/src/handleEvent.ts
+++ b/src/handleEvent.ts
@@ -142,7 +142,9 @@ export function handleEvent<Context = unknown, Event = unknown>(
 
             if (hasIrregularEventKeys) {
                 ;(<unknown[]>Actions).push(
-                    ...irregularEventKeys.map((key) => handler[key])
+                    ...irregularEventKeys.map((key) => {
+                        return { [key]: handler[key] }
+                    })
                 )
             }
 


### PR DESCRIPTION
This PR fixes irregular events being handled incorrectly.

What was happening before this PR was when an "irregular event" showed up, i.e.
```json
{
    "$set": ["Count", "$Value.TotalMercesEarned"]
}
```

`handleEvent` would transform it like so before passing it to `handleActions`:
`[["Count", "$Value.TotalMercesEarned"]]`
Completely removing the opcode, meaning nothing would happen.

It should've transformed it to this:
`[{ "$set": ["Count", "$Value.TotalMercesEarned"] }`
Preserving the opcode and operands.

We should probably add some tests for irregular events, but what we'd test exactly, I'm unsure about.

Fixes thepeacockproject/Peacock#197 (and most likely many other challenges that use this).