### PR TITLE
Add support for `$reset`

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -17,6 +17,7 @@ This is a list of the possible nodes that can appear in a state machine, and wha
     -   [`$inc` and `$dec`](#inc-dec)
     -   [`$mul`](#mul)
     -   [`$push`](#push)
+    -   [`$reset`](#reset)
 -   [Common Nodes](#common-nodes)
     -   [`$pushunique`](#pushunique)
 
@@ -189,6 +190,21 @@ Example:
 {
     // sets the value of `CoolestCharacter` to "Rocco"
     $set: ["$CoolestCharacter", "Rocco"],
+}
+```
+
+### `$reset`
+
+This node sets the value of a context variable to an empty array (i.e. resetting the array).
+
+The node itself is given the name of the variable.
+
+Example:
+
+```json5
+{
+    // resets the array "Targets"
+    $reset: "Targets"
 }
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -416,6 +416,12 @@ export function handleActions<Context>(
         set(context, reference, array)
     }
 
+    if (has("$reset")) {
+        let reference = input.$reset[0]
+
+        set(context, reference, [])
+    }
+
     return context
 }
 

--- a/tests/reset.spec.ts
+++ b/tests/reset.spec.ts
@@ -40,12 +40,12 @@ describe("$reset", () => {
     it("can reset a non-empty array", () => {
         const [sm, vars] = data.Reset1
         const r = handleActions(sm, vars)
-        assert.strictEqual(r.Targets, [])
+        assert.strictEqual(r.Targets?.length, 0)
     })
 
     it("can reset an empty array", () => {
         const [sm, vars] = data.Reset2
         const r = handleActions(sm, vars)
-        assert.strictEqual(r.Targets, [])
+        assert.strictEqual(r.Targets?.length, 0)
     })
 })

--- a/tests/reset.spec.ts
+++ b/tests/reset.spec.ts
@@ -1,0 +1,51 @@
+/*
+ *    Copyright (c) 2022-2023 The Peacock Project
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+import { handleActions } from "../src"
+import assert from "assert"
+
+const data = {
+    Reset1: [
+        {
+            $reset: ["Targets"],
+        },
+        {
+            Targets: ["RDIL", "MoonySolari", "Tony"]
+        },
+    ],
+    Reset2: [
+        {
+            $reset: "Targets",
+        },
+        {
+            Targets: []
+        },
+    ],
+}
+
+describe("$reset", () => {
+    it("can reset a non-empty array", () => {
+        const [sm, vars] = data.Reset1
+        const r = handleActions(sm, vars)
+        assert.strictEqual(r.Targets, [])
+    })
+
+    it("can reset an empty array", () => {
+        const [sm, vars] = data.Reset2
+        const r = handleActions(sm, vars)
+        assert.strictEqual(r.Targets, [])
+    })
+})


### PR DESCRIPTION
This PR adds support for the `$reset` opcode, which, presumably resets an array to an empty one.

No tests included, this is a pretty basic opcode.