### PR TITLE
Delete values regardless of whether they are truthy

### DIFF
--- a/src/handleEvent.ts
+++ b/src/handleEvent.ts
@@ -176,8 +176,7 @@ export function handleEvent<Context = unknown, Event = unknown>(
             }
 
             // drop this specific event's ContractId
-            // @ts-expect-error
-            if (newContext.ContractId) {
+            if (newContext.hasOwnProperty("ContractId")) {
                 // @ts-expect-error
                 delete newContext.ContractId
             }

--- a/src/handleEvent.ts
+++ b/src/handleEvent.ts
@@ -91,12 +91,12 @@ export function handleEvent<Context = unknown, Event = unknown>(
             conditionResult = test(
                 handler.Condition,
                 {
-                    Value: event,
                     ...(options.contractId && {
                         ContractId: options.contractId,
                     }),
                     ...(newContext || {}),
                     ...(definition.Constants || {}),
+                    Value: event,
                 },
                 {
                     pushUniqueAction(reference, item) {
@@ -155,23 +155,22 @@ export function handleEvent<Context = unknown, Event = unknown>(
                             [action]: actionSet[action],
                         },
                         {
-                            Value: event,
                             ...(options.contractId && {
                                 ContractId: options.contractId,
                             }),
                             ...newContext,
                             ...(definition.Constants || {}),
+                            Value: event,
                         },
                         {
-                            originalContext: definition.Context ?? {}
-                        },
+                            originalContext: definition.Context ?? {},
+                        }
                     )
                 }
             }
 
             // drop this specific event's value
-            // @ts-expect-error
-            if (newContext.Value) {
+            if (newContext.hasOwnProperty("Value")) {
                 // @ts-expect-error
                 delete newContext.Value
             }

--- a/src/handleEvent.ts
+++ b/src/handleEvent.ts
@@ -91,10 +91,10 @@ export function handleEvent<Context = unknown, Event = unknown>(
             conditionResult = test(
                 handler.Condition,
                 {
+                    ...(newContext || {}),
                     ...(options.contractId && {
                         ContractId: options.contractId,
                     }),
-                    ...(newContext || {}),
                     ...(definition.Constants || {}),
                     Value: event,
                 },
@@ -155,10 +155,10 @@ export function handleEvent<Context = unknown, Event = unknown>(
                             [action]: actionSet[action],
                         },
                         {
+                            ...newContext,
                             ...(options.contractId && {
                                 ContractId: options.contractId,
                             }),
-                            ...newContext,
                             ...(definition.Constants || {}),
                             Value: event,
                         },


### PR DESCRIPTION
`Value` and `ContractId` were only deleted from the context when they are truthy. This caused some challenge contexts to have `Value: ""` in them (see issue 207 in the Peacock repo). This pr fixes this. It also changes the way the `Value` is passed such that if the context already has `Value: ""`, it will not overwrite the actual `Value` that needs to be passed (same for `ContractId`). Ultimately, this PR fixes Mirror Mirror on the Wall being broken.