### PR TITLE
Timer fix, again.

### DIFF
--- a/src/handleEvent.ts
+++ b/src/handleEvent.ts
@@ -254,8 +254,6 @@ export function handleEvent<Context = unknown, Event = unknown>(
         eventHandlers = [eventHandlers].filter(Boolean)
     }
 
-    let timerResult = undefined
-
     if (hasTimerState) {
         const timerState = csObject.$timer
         const timerEventHandlers: EHArray = []
@@ -270,14 +268,22 @@ export function handleEvent<Context = unknown, Event = unknown>(
 
         // Timers are a special snowflake, if they cause a state transition we have to continue processing normal events.
         // Since the handlers don't know what they are processing and to prevent constantly checking for timers, we just run them separately.
-        timerResult = doEventHandlers(timerEventHandlers)
+        const timerResult = doEventHandlers(timerEventHandlers)
+
+        //If the timer resulted in a state transition, we have to replay the current event again.
+        if (timerResult) {
+            log(
+                "timer",
+                "Timer caused a state transition, replaying current event with new state."
+            )
+
+            options.currentState = timerResult.state
+
+            return handleEvent(definition, timerResult.context, event, options)
+        }
     }
 
     const result = doEventHandlers(eventHandlers)
-
-    if (timerResult) {
-        return timerResult
-    }
 
     if (result) {
         return result

--- a/src/handleEvent.ts
+++ b/src/handleEvent.ts
@@ -270,7 +270,7 @@ export function handleEvent<Context = unknown, Event = unknown>(
         // Since the handlers don't know what they are processing and to prevent constantly checking for timers, we just run them separately.
         const timerResult = doEventHandlers(timerEventHandlers)
 
-        //If the timer resulted in a state transition, we have to replay the current event again.
+        // If the timer resulted in a state transition, we have to replay the current event again.
         if (timerResult) {
             log(
                 "timer",


### PR DESCRIPTION
Follow-up on #20, but with proper replay of the current event in the new state.

Quick explanation:
- If the current state has a $timer event handler(s), it's run before other event handlers get a chance.
- If this $timer causes a state transition (eg. because the timer expired), in the old situation it would ignore it and continue with the other event handlers. The problem with that is that the other event handlers will be executed towards the wrong `csObject`, since it's gathered using the currentState at the start of the function: `let csObject = definition.States?.[currentState]`. So now, instead of silently ignoring a state change, we handle it by recursively calling ourselves again, but with the updated currentState. This will have removed any expired timers as well as make sure that new timers get a chance to start.

AKA: If timer causes state transition, restart with new currentState, rather than continuing with old one, effectively executing the wrong event handlers as a result.