### PR TITLE
Add type checking to some actions

### DIFF
--- a/src/handleEvent.ts
+++ b/src/handleEvent.ts
@@ -111,10 +111,8 @@ export function handleEvent<Context = unknown, Event = unknown>(
                             `Running pushUniqueAction on ${reference} with ${item}`
                         )
 
-                        if (!referenceArray) {
-                            throw new Error(
-                                `Could not find ${reference} in context`
-                            )
+                        if (!Array.isArray(referenceArray)) {
+                            return false
                         }
 
                         if (referenceArray.includes(item)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -310,9 +310,9 @@ export function handleActions<Context>(
 
     const addOrDec = (op: string) => {
         if (typeof input[op] === "string") {
-            const variableValue = findNamedChild(input[op], context, true)
-
             let reference = input[op]
+
+            const variableValue = findNamedChild(input[op], context, true)
 
             set(
                 context,

--- a/src/index.ts
+++ b/src/index.ts
@@ -314,6 +314,10 @@ export function handleActions<Context>(
 
             const variableValue = findNamedChild(input[op], context, true)
 
+            if (typeof variableValue !== "number") {
+                return
+            }
+
             set(
                 context,
                 reference,
@@ -324,6 +328,10 @@ export function handleActions<Context>(
 
             const variableValue = findNamedChild(reference, context, true)
             const incrementBy = findNamedChild(input[op][1], context, false)
+
+            if (typeof variableValue !== "number") {
+                return
+            }
 
             set(
                 context,
@@ -347,6 +355,10 @@ export function handleActions<Context>(
 
         // clone the thing
         const array = deepClone(findNamedChild(reference, context, true))
+
+        if (!Array.isArray(array)) {
+            return
+        }
 
         if (unique) {
             if (array.indexOf(value) === -1) {
@@ -388,6 +400,10 @@ export function handleActions<Context>(
                     false
                 )
 
+                if (typeof variableValue1 !== "number" || typeof variableValue2 !== "number") {
+                    break
+                }
+
                 set(context, reference, variableValue1 * variableValue2)
                 break
             }
@@ -415,6 +431,10 @@ export function handleActions<Context>(
                 }
 
                 const value = findNamedChild(input.$remove[1], context, false)
+
+                if (!Array.isArray(value)) {
+                    break
+                }
 
                 // clone the thing
                 let array: unknown[] = deepClone(

--- a/src/index.ts
+++ b/src/index.ts
@@ -432,14 +432,14 @@ export function handleActions<Context>(
 
                 const value = findNamedChild(input.$remove[1], context, false)
 
-                if (!Array.isArray(value)) {
-                    break
-                }
-
                 // clone the thing
                 let array: unknown[] = deepClone(
                     findNamedChild(reference, context, true)
                 )
+
+                if (!Array.isArray(array)) {
+                    break
+                }
 
                 array = array.filter((item) => item !== value)
 

--- a/tests/edge-cases.spec.ts
+++ b/tests/edge-cases.spec.ts
@@ -47,23 +47,31 @@ describe("edge cases", () => {
 
     describe("trying to modify non-existant context vars does not error", () => {
         it("using the $inc action", () => {
-            const action = {
+            const action1 = {
                 $inc: ["MyCoolArray", 1],
+            }
+            const action2 = {
+                $inc: "MyCoolArray"
             }
             const context = {}
             
-            const newContext = handleActions(action, context)
+            let newContext = handleActions(action1, context)
+            newContext = handleActions(action2, newContext)
 
             assert.deepStrictEqual(newContext, {})
         })
 
         it("using the $dec action", () => {
-            const action = {
+            const action1 = {
                 $dec: ["MyCoolArray", 2],
+            }
+            const action2 = {
+                $dec: "MyCoolArray",
             }
             const context = {}
             
-            const newContext = handleActions(action, context)
+            let newContext = handleActions(action1, context)
+            newContext = handleActions(action2, newContext)
 
             assert.deepStrictEqual(newContext, {})
         })

--- a/tests/edge-cases.spec.ts
+++ b/tests/edge-cases.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import { findNamedChild, set } from "../src/utils"
+import { handleActions, handleEvent } from "../src"
 import * as assert from "assert"
 
 describe("edge cases", () => {
@@ -41,6 +42,106 @@ describe("edge cases", () => {
                 `{"JNames":["bob","bill","ben"]}`,
                 "values not equal"
             )
+        })
+    })
+
+    describe("trying to modify non-existant context vars does not error", () => {
+        it("using the $inc action", () => {
+            const action = {
+                $inc: ["MyCoolArray", 1],
+            }
+            const context = {}
+            
+            const newContext = handleActions(action, context)
+
+            assert.deepStrictEqual(newContext, {})
+        })
+
+        it("using the $dec action", () => {
+            const action = {
+                $dec: ["MyCoolArray", 2],
+            }
+            const context = {}
+            
+            const newContext = handleActions(action, context)
+
+            assert.deepStrictEqual(newContext, {})
+        })
+
+        it("using the $mul action", () => {
+            const action = {
+                $mul: ["MyCoolArray", 3],
+            }
+            const context = {}
+            
+            const newContext = handleActions(action, context)
+
+            assert.deepStrictEqual(newContext, {})
+        })
+
+        it("using the $push action", () => {
+            const action = {
+                $push: ["MyCoolArray", 4],
+            }
+            const context = {}
+            
+            const newContext = handleActions(action, context)
+
+            assert.deepStrictEqual(newContext, {})
+        })
+
+        it("using the $pushunique action", () => {
+            const action = {
+                $pushunique: ["MyCoolArray", 5],
+            }
+            const context = {}
+            
+            const newContext = handleActions(action, context)
+
+            assert.deepStrictEqual(newContext, {})
+        })
+
+        it("using the $remove action", () => {
+            const action = {
+                $remove: ["MyCoolArray", 6],
+            }
+            const context = {}
+            
+            const newContext = handleActions(action, context)
+
+            assert.deepStrictEqual(newContext, {})
+        })
+
+        it("using the $pushunique condition", () => {
+            const Definition = {
+                Context: {},
+                States: {
+                    Start: {
+                        EventName: {
+                            Condition: {
+                                $pushunique: ["MyOtherCoolArray", "bofa"],
+                            },
+                        },
+                    },
+                },
+            }
+            const Input = {
+                Name: "EventName",
+                Value: {},
+            }
+
+            const result = handleEvent(
+                Definition,
+                Definition.Context,
+                Input.Value,
+                {
+                    currentState: "Start",
+                    eventName: Input.Name,
+                    timestamp: 0,
+                },
+            )
+
+            assert.deepStrictEqual(result.context, {})
         })
     })
 })


### PR DESCRIPTION
Add type checks to some actions.
Actions acting on wrong data types (e.x. `$inc: ["a-string", 4]`, or `$mul: ["$.aVariable", 3]`, where `$.aVariable` does not exist) will now do nothing, as it should.
I have not tested every possible combination of types in-game, but from the ones I've tested, I think it's safe to conclude that using $inc, $dec, and $mul with non-numbers does nothing.
Similarly, using $push, $pushunique, or $remove with non-arrays also does nothing.
The same is true if these actions are trying to use (context) variables that are undefined.

Should fix https://github.com/thepeacockproject/Peacock/issues/479.