### PR TITLE
Fix: $eq condition where first value is null or undefined should always return false

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "hbenl.vscode-mocha-test-adapter",
+        "esbenp.prettier-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "npm.packageManager": "yarn",
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "[typescript]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "mochaExplorer.files": ["tests/**/*.{js,ts,cjs,mjs}"],
+    "mochaExplorer.require": [
+        "esbuild-register"
+    ]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,8 @@ function realTest<Variables>(
 
             const res = testWithPath(input.$eq[0], variables, options, "$eq[0]")
 
+            if (res == null) return false
+
             return (
                 // we test for each element because we need to make sure that the value is fixed if it's a variable
                 input.$eq.every(

--- a/tests/eq.spec.ts
+++ b/tests/eq.spec.ts
@@ -75,6 +75,32 @@ const data = {
         },
         {},
     ],
+    UndefinedCheck1: [
+        {
+            $eq: ["$Value.a"],
+        },
+        {
+            Value: {},
+        },
+    ],
+    UndefinedCheck2: [
+        {
+            $eq: ["$Value.a", "$Value.a"],
+        },
+        {
+            Value: {},
+        },
+    ],
+    NullCheck2: [
+        {
+            $eq: ["$Value.a", "$Value.a"],
+        },
+        {
+            Value: {
+                a: null,
+            },
+        },
+    ],
 }
 
 describe("$eq", () => {
@@ -115,5 +141,22 @@ describe("$eq", () => {
     it("array with more than 2 elements", () => {
         const [sm, vars] = data.LongArray1
         assert.strictEqual(test(sm, vars), true)
+    })
+
+    context("$eq with undefined or null variables", () => {
+        it("1 (one) undefined variable", () => {
+            const [sm, vars] = data.UndefinedCheck1
+            assert.strictEqual(test(sm, vars), false)
+        })
+
+        it("2 undefined variables", () => {
+            const [sm, vars] = data.UndefinedCheck2
+            assert.strictEqual(test(sm, vars), false)
+        })
+
+        it("2 null variables", () => {
+            const [sm, vars] = data.NullCheck2
+            assert.strictEqual(test(sm, vars), false)
+        })
     })
 })


### PR DESCRIPTION
See title.
Fixes https://github.com/thepeacockproject/Peacock/issues/530.

I've also added some settings / extension recommendations for vscode to make running tests a bit easier.